### PR TITLE
[PR] Merge reference-based implementation

### DIFF
--- a/src/main/java/org/example/anorakapi/AnorakApiController.java
+++ b/src/main/java/org/example/anorakapi/AnorakApiController.java
@@ -29,8 +29,8 @@ public class AnorakApiController {
     }
 
     @GetMapping("/train/{id}/sightings")
-    public Map<String, List<Sighting>> getSightings(@PathVariable String id){
-        List<Sighting> sightings = anorakApiService.getSightingsByTrainId(id);
+    public Map<String, List<SightingDTO>> getSightings(@PathVariable String id){
+        List<SightingDTO> sightings = anorakApiService.getSightingsByTrainId(id);
         return Map.of("sightings", sightings);
     }
 
@@ -42,8 +42,8 @@ public class AnorakApiController {
 
     @PostMapping("/sightings")
     @ResponseStatus(HttpStatus.CREATED)
-    public Map<String, List<Sighting>> saveSightings(@Valid @RequestBody List<Sighting> sightings) {
-        List<Sighting> returnedSightings = anorakApiService.saveSightings(sightings);
+    public Map<String, List<SightingDTO>> saveSightings(@Valid @RequestBody List<SightingDTO> sightings) {
+        List<SightingDTO> returnedSightings = anorakApiService.saveSightings(sightings);
         return Map.of("sightings", returnedSightings);
     }
 }

--- a/src/main/java/org/example/anorakapi/SightingDTO.java
+++ b/src/main/java/org/example/anorakapi/SightingDTO.java
@@ -1,29 +1,17 @@
 package org.example.anorakapi;
 
 import com.google.cloud.firestore.DocumentReference;
-import com.google.cloud.firestore.annotation.DocumentId;
-import com.google.cloud.spring.data.firestore.Document;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeParseException;
 
-@Document(collectionName = "sightingz")
-public class Sighting {
-    @DocumentId
+public class SightingDTO {
     private String id;
-
-    @NotNull(message = "Station reference is required")
-    private DocumentReference station;
-
-    @NotNull(message = "Train reference is required")
-    private DocumentReference train;
-
-    @NotBlank(message = "Timestamp cannot be empty")
+    private Station station;
+    private Train train;
     private String timestamp;
 
-    Sighting(DocumentReference station, DocumentReference train, String timestamp) throws IllegalArgumentException {
+    SightingDTO(Station station, Train train, String timestamp) throws IllegalArgumentException {
         if (station == null || train == null || timestamp == null) {
             throw new IllegalArgumentException("Station, Train or Timestamp cannot be null");
         }
@@ -40,7 +28,7 @@ public class Sighting {
         this.timestamp = timestamp; // still stored as string
     }
 
-    public Sighting() {
+    public SightingDTO() {
 
     }
 
@@ -50,19 +38,19 @@ public class Sighting {
     public void setId(String id) {
         this.id = id;
     }
-    public DocumentReference getStation(){
+    public Station getStation(){
         return station;
     }
-    public DocumentReference getTrain(){
+    public Train getTrain(){
         return train;
     }
     public String getTimestamp() {
         return timestamp;
     }
-    public void setTrain(DocumentReference train) {
+    public void setTrain(Train train) {
         this.train = train;
     }
-    public void setStation(DocumentReference station) {
+    public void setStation(Station station) {
         this.station = station;
     }
 

--- a/src/test/java/org/example/anorakapi/AnorakApiApplicationTests.java
+++ b/src/test/java/org/example/anorakapi/AnorakApiApplicationTests.java
@@ -129,8 +129,8 @@ class AnorakApiApplicationTests {
         train.setId("train-123");
         Station station = new Station("Liverpool Street");
         station.setId("station-456");
-        Sighting sighting = new Sighting(station, train, "2025-08-25T10:15:30Z");
-        List<Sighting> sightings = List.of(sighting);
+        SightingDTO sighting = new SightingDTO(station, train, "2025-08-25T10:15:30Z");
+        List<SightingDTO> sightings = List.of(sighting);
 
         when(anorakApiService.getSightingsByTrainId("train-123")).thenReturn(sightings);
 
@@ -174,7 +174,7 @@ class AnorakApiApplicationTests {
 
         Train train = new Train("Express 1", "Red", "12345");
         Station station = new Station("London Euston");
-        Sighting sighting = new Sighting();
+        SightingDTO sighting = new SightingDTO();
         sighting.setTrain(train);
         sighting.setStation(station);
         sighting.setTimestamp("2025-08-25T17:35:42Z");
@@ -234,7 +234,7 @@ class AnorakApiApplicationTests {
 
         Train train1 = new Train("Express 1", "Red", "12345");
         Station station1 = new Station("London Euston");
-        Sighting sighting1 = new Sighting();
+        SightingDTO sighting1 = new SightingDTO();
         sighting1.setTrain(train1);
         sighting1.setStation(station1);
         sighting1.setTimestamp("2025-08-25T17:35:42Z");
@@ -271,14 +271,14 @@ class AnorakApiApplicationTests {
 
         Train t1 = new Train("Express 1", "Red", "12345");
         Station s1 = new Station("London Euston");
-        Sighting sighting1 = new Sighting();
+        SightingDTO sighting1 = new SightingDTO();
         sighting1.setTrain(t1);
         sighting1.setStation(s1);
         sighting1.setTimestamp("2025-08-25T17:35:42Z");
 
         Train t2 = new Train("Express 2", "Blue", "54321");
         Station s2 = new Station("Manchester Piccadilly");
-        Sighting sighting2 = new Sighting();
+        SightingDTO sighting2 = new SightingDTO();
         sighting2.setTrain(t2);
         sighting2.setStation(s2);
         sighting2.setTimestamp("2025-08-25T18:00:00Z");

--- a/src/test/java/org/example/anorakapi/SightingDTOTest.java
+++ b/src/test/java/org/example/anorakapi/SightingDTOTest.java
@@ -1,0 +1,89 @@
+package org.example.anorakapi;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockitoExtension.class)
+public class SightingDTOTest {
+
+    @Mock
+    private Train train;
+    private Station station;
+
+    @BeforeEach
+    void setUp() {
+        train = new Train("Henry", "Green", "NWR3");
+        station = new Station("Liverpool Street");
+    }
+
+    @Test
+    @DisplayName("Tests creation of Sighting DTO object and its methods")
+    void testSightingDTO_CreationAndGetMethods() {
+        SightingDTO dto = new SightingDTO(station, train, "2025-08-25T17:35:42.123Z");
+        dto.setId("mock-id-123");
+
+        assertEquals("mock-id-123", dto.getId());
+        assertEquals("Liverpool Street", dto.getStation().getName());
+        assertEquals("Henry", dto.getTrain().getName());
+        assertEquals("2025-08-25T17:35:42.123Z", dto.getTimestamp());
+    }
+
+    @Test
+    @DisplayName("SightingDTO should throw exception if timestamp is empty")
+    void testSightingDTO_ShouldFail_IfTimestampEmpty() {
+        Exception ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> new SightingDTO(station, train, "")
+        );
+        assertEquals("Timestamp cannot be an empty string", ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("SightingDTO should throw exception if timestamp is not correctly formatted")
+    void testSightingDTO_ShouldFail_IfTimestampInvalidFormat() {
+        Exception ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> new SightingDTO(station, train, "2025-08-2517:35:00")
+        );
+        assertEquals("Timestamp is an incorrect format", ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("SightingDTO should throw exception if station is null")
+    void testSightingDTO_ShouldFail_IfStationNull() {
+        Exception ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> new SightingDTO(null, train, "2025-08-25T17:35:42.123Z")
+        );
+        assertEquals("Station, Train or Timestamp cannot be null", ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("SightingDTO should throw exception if train is null")
+    void testSightingDTO_ShouldFail_IfTrainNull() {
+        Exception ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> new SightingDTO(station, null, "2025-08-25T17:35:42.123Z")
+        );
+        assertEquals("Station, Train or Timestamp cannot be null", ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("SightingDTO should throw exception if timestamp is null")
+    void testSightingDTO_ShouldFail_IfTimestampNull() {
+        Exception ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> new SightingDTO(station, train, null)
+        );
+        assertEquals("Station, Train or Timestamp cannot be null", ex.getMessage());
+    }
+
+
+}

--- a/src/test/java/org/example/anorakapi/SightingTest.java
+++ b/src/test/java/org/example/anorakapi/SightingTest.java
@@ -1,93 +1,82 @@
 package org.example.anorakapi;
 
+import com.google.cloud.firestore.DocumentReference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import reactor.core.publisher.Mono;
-
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mock;
 
-@ExtendWith(MockitoExtension.class)
 public class SightingTest {
 
-    @Mock
-    private SightingRepository sightingRepository;
-    private Train train;
-    private Station station;
+    private DocumentReference trainRef;
+    private DocumentReference stationRef;
 
     @BeforeEach
     void setUp() {
-        train = new Train("Henry", "Green", "NWR3");
-        station = new Station("Liverpool Street");
+        trainRef = mock(DocumentReference.class);
+        stationRef = mock(DocumentReference.class);
     }
 
     @Test
-    @DisplayName("Tests creation of Sighting object and its methods")
+    @DisplayName("Tests creation of Sighting object and its getters")
     void testSightingCreationAndGetMethods() {
-        Sighting sighting = new Sighting(station, train, "2025-08-25T17:35:42.123Z");
-        Sighting sightingWithId = new Sighting(station, train, "2025-08-25T17:35:42.123Z");
-        sightingWithId.setId("mock-id-123");
+        String timestamp = "2025-08-25T17:35:42.123Z";
+        Sighting sighting = new Sighting(stationRef, trainRef, timestamp);
+        sighting.setId("mock-id-123");
 
-        when(sightingRepository.save(sighting)).thenReturn(Mono.just(sightingWithId));
-
-        Sighting savedSighting = sightingRepository.save(sighting).block();
-
-        assertNotNull(savedSighting.getId(), "ID should not be null");
-        assertEquals("Liverpool Street", savedSighting.getStation().getName());
-        assertEquals("Henry", savedSighting.getTrain().getName());
-        assertEquals("2025-08-25T17:35:42.123Z", savedSighting.getTimestamp());
+        assertEquals("mock-id-123", sighting.getId());
+        assertEquals(stationRef, sighting.getStation());
+        assertEquals(trainRef, sighting.getTrain());
+        assertEquals(timestamp, sighting.getTimestamp());
     }
 
     @Test
-    @DisplayName("Sighting should throw exception if timestamp is empty.")
-    void testSightingCreation_ShouldFail_IfTimestampEmptyString() {
+    @DisplayName("Sighting should throw exception if timestamp is empty")
+    void testSighting_ShouldFail_IfTimestampEmpty() {
         Exception ex = assertThrows(
                 IllegalArgumentException.class,
-                () -> new Sighting(station, train, "")
+                () -> new Sighting(stationRef, trainRef, "")
         );
         assertEquals("Timestamp cannot be an empty string", ex.getMessage());
     }
 
     @Test
-    @DisplayName("Sighting should throw exception if timestamp is not correctly formatted.")
-    void testSightingCreation_ShouldFail_IfTimestampNotCorrectlyFormatted() {
+    @DisplayName("Sighting should throw exception if timestamp is invalid format")
+    void testSighting_ShouldFail_IfTimestampInvalidFormat() {
         Exception ex = assertThrows(
                 IllegalArgumentException.class,
-                () -> new Sighting(station, train, "2025-08-2517:35:00")
+                () -> new Sighting(stationRef, trainRef, "2025-08-2517:35:00")
         );
         assertEquals("Timestamp is an incorrect format", ex.getMessage());
     }
 
     @Test
-    @DisplayName("Sighting should throw exception if sighting name null.")
-    void testSightingCreation_ShouldFail_IfSightingStationNull() {
+    @DisplayName("Sighting should throw exception if station is null")
+    void testSighting_ShouldFail_IfStationNull() {
         Exception ex = assertThrows(
                 IllegalArgumentException.class,
-                () -> new Sighting(null, train, "2025-08-25T17:35:42.123Z")
+                () -> new Sighting(null, trainRef, "2025-08-25T17:35:42.123Z")
         );
         assertEquals("Station, Train or Timestamp cannot be null", ex.getMessage());
     }
 
     @Test
-    @DisplayName("Sighting should throw exception if sighting train null.")
-    void testSightingCreation_ShouldFail_IfSightingTrainNull() {
+    @DisplayName("Sighting should throw exception if train is null")
+    void testSighting_ShouldFail_IfTrainNull() {
         Exception ex = assertThrows(
                 IllegalArgumentException.class,
-                () -> new Sighting(station, null, "2025-08-25T17:35:42.123Z")
+                () -> new Sighting(stationRef, null, "2025-08-25T17:35:42.123Z")
         );
         assertEquals("Station, Train or Timestamp cannot be null", ex.getMessage());
     }
 
     @Test
-    @DisplayName("Sighting should throw exception if sighting timestamp null.")
-    void testSightingCreation_ShouldFail_IfSightingTimestampNull() {
+    @DisplayName("Sighting should throw exception if timestamp is null")
+    void testSighting_ShouldFail_IfTimestampNull() {
         Exception ex = assertThrows(
                 IllegalArgumentException.class,
-                () -> new Sighting(station, train, null)
+                () -> new Sighting(stationRef, trainRef, null)
         );
         assertEquals("Station, Train or Timestamp cannot be null", ex.getMessage());
     }


### PR DESCRIPTION
Merging reference-based implementation that instead looks at firebase with reference points (e.g. "train": "train/123") rather than repeatedly storing duplicates of the same objects in the sightings. This allows the API to display endpoints as normal while eliminating duplication and redundancy on the backend side.
This was done by splitting the Sighting class into two, with one 'DTO' acting as the original implementation and the other acting as a ReferenceLookup so that objects could be correctly loaded using the reference.
